### PR TITLE
Update SBT and plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ project/plugins/project/
 .history
 .cache
 .lib/
+.metals/
+.bloop/
 
 ### Scala template
 *.class

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,3 @@
+version=2.3.2
 align = true
 maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,13 @@ lazy val buildSettings = Seq(
     "-Dspark.shuffle.sort.bypassMergeThreshold=2",
     "-Dlighthouse.environment=test"
   ),
-  scalacOptions ++= Seq("-Ypartial-unification", "-deprecation"),
+  scalacOptions ++= Seq(
+    "-deprecation",
+    "-optimize",
+    "-unchecked",
+    "-Ydelambdafy:inline",
+    "-Ypartial-unification"
+  ),
   // Git versioning
   git.useGitDescribe := true,
   git.baseVersion := "0.0.0",
@@ -29,9 +35,11 @@ lazy val buildSettings = Seq(
   publishTo := Some(if (isSnapshot.value) datamindedSnapshots else sonatypeStaging),
   homepage := Some(url("https://github.com/datamindedbe/lighthouse")),
   scmInfo := Some(
-    ScmInfo(url("https://github.com/datamindedbe/lighthouse"), "git@github.com:datamindedbe/lighthouse.git")),
+    ScmInfo(url("https://github.com/datamindedbe/lighthouse"), "git@github.com:datamindedbe/lighthouse.git")
+  ),
   developers := List(
-    Developer("mlavaert", "Mathias Lavaert", "mathias.lavaert@dataminded.be", url("https://github.com/mlavaert"))),
+    Developer("mlavaert", "Mathias Lavaert", "mathias.lavaert@dataminded.be", url("https://github.com/mlavaert"))
+  ),
   licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 )
 
@@ -43,10 +51,18 @@ lazy val `lighthouse-platform` = (project in file("."))
 lazy val lighthouse = (project in file("lighthouse-core"))
   .dependsOn(`lighthouse-testing` % "test->compile")
   .enablePlugins(SiteScaladocPlugin)
-  .settings(buildSettings, libraryDependencies ++= commonDependencies ++ Seq(cats, typesafeConfig), crossScalaVersions := supportedScalaVersions)
+  .settings(
+    buildSettings,
+    libraryDependencies ++= commonDependencies ++ Seq(cats, typesafeConfig),
+    crossScalaVersions := supportedScalaVersions
+  )
 
 lazy val `lighthouse-testing` = (project in file("lighthouse-testing"))
-  .settings(buildSettings, libraryDependencies ++= Seq(sparkSql, sparkHive, scalaTest, betterFiles), crossScalaVersions := supportedScalaVersions)
+  .settings(
+    buildSettings,
+    libraryDependencies ++= Seq(sparkSql, sparkHive, scalaTest, betterFiles),
+    crossScalaVersions := supportedScalaVersions
+  )
 
 lazy val `lighthouse-demo` = (project in file("lighthouse-demo"))
   .dependsOn(lighthouse, `lighthouse-testing` % "test->compile")

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/AvroDataLink.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/AvroDataLink.scala
@@ -2,11 +2,12 @@ package be.dataminded.lighthouse.datalake
 
 import org.apache.spark.sql.{DataFrame, Dataset, SaveMode}
 
-class AvroDataLink(val path: LazyConfig[String],
-                   saveMode: SaveMode = SaveMode.Overwrite,
-                   partitionedBy: List[String] = List.empty,
-                   options: Map[String, String] = Map.empty)
-    extends PathBasedDataLink {
+class AvroDataLink(
+    val path: LazyConfig[String],
+    saveMode: SaveMode = SaveMode.Overwrite,
+    partitionedBy: List[String] = List.empty,
+    options: Map[String, String] = Map.empty
+) extends PathBasedDataLink {
 
   override def doRead(path: String): DataFrame = {
     spark.read

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/FileSystemDataLink.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/FileSystemDataLink.scala
@@ -13,13 +13,14 @@ import org.apache.spark.sql.{DataFrame, Dataset, SaveMode}
   * @param saveMode      the save mode to apply (overwrite, append)
   * @param partitionedBy the partitioning to apply
   */
-class FileSystemDataLink(val path: LazyConfig[String],
-                         format: SparkFileFormat = Orc,
-                         saveMode: SaveMode = SaveMode.Overwrite,
-                         partitionedBy: List[String] = List.empty,
-                         options: Map[String, String] = Map.empty,
-                         schema: Option[StructType] = None)
-    extends PathBasedDataLink {
+class FileSystemDataLink(
+    val path: LazyConfig[String],
+    format: SparkFileFormat = Orc,
+    saveMode: SaveMode = SaveMode.Overwrite,
+    partitionedBy: List[String] = List.empty,
+    options: Map[String, String] = Map.empty,
+    schema: Option[StructType] = None
+) extends PathBasedDataLink {
 
   override def doRead(path: String): DataFrame = {
     schema match {

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/HiveDataLink.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/HiveDataLink.scala
@@ -32,15 +32,16 @@ import org.apache.spark.sql.{DataFrame, Dataset, SaveMode}
   * @param database           The name of the database
   * @param table              The name of the table
   */
-class HiveDataLink(val path: LazyConfig[String],
-                   database: LazyConfig[String],
-                   table: LazyConfig[String],
-                   format: SparkFileFormat = Orc,
-                   saveMode: SaveMode = SaveMode.Overwrite,
-                   partitionedBy: List[String] = Nil,
-                   overwriteBehavior: SparkOverwriteBehavior = FullOverwrite,
-                   options: Map[String, String] = Map.empty)
-    extends PathBasedDataLink {
+class HiveDataLink(
+    val path: LazyConfig[String],
+    database: LazyConfig[String],
+    table: LazyConfig[String],
+    format: SparkFileFormat = Orc,
+    saveMode: SaveMode = SaveMode.Overwrite,
+    partitionedBy: List[String] = Nil,
+    overwriteBehavior: SparkOverwriteBehavior = FullOverwrite,
+    options: Map[String, String] = Map.empty
+) extends PathBasedDataLink {
 
   override def doRead(path: String): DataFrame = {
     spark.catalog.setCurrentDatabase(database())

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/JdbcDataLink.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/datalake/JdbcDataLink.scala
@@ -25,17 +25,18 @@ import scala.util.{Failure, Success, Try}
   *                           is taken to decide the batch size
   * @param saveMode           Spark sql SaveMode
   */
-class JdbcDataLink(url: LazyConfig[String],
-                   username: LazyConfig[String],
-                   password: LazyConfig[String],
-                   driver: LazyConfig[String],
-                   table: LazyConfig[String],
-                   extraProperties: LazyConfig[Map[String, String]] = LazyConfig(Map.empty[String, String]),
-                   partitionColumn: LazyConfig[String] = "",
-                   numberOfPartitions: LazyConfig[Int] = 0,
-                   batchSize: LazyConfig[Int] = 50000,
-                   saveMode: SaveMode = SaveMode.Append)
-    extends DataLink {
+class JdbcDataLink(
+    url: LazyConfig[String],
+    username: LazyConfig[String],
+    password: LazyConfig[String],
+    driver: LazyConfig[String],
+    table: LazyConfig[String],
+    extraProperties: LazyConfig[Map[String, String]] = LazyConfig(Map.empty[String, String]),
+    partitionColumn: LazyConfig[String] = "",
+    numberOfPartitions: LazyConfig[Int] = 0,
+    batchSize: LazyConfig[Int] = 50000,
+    saveMode: SaveMode = SaveMode.Append
+) extends DataLink {
 
   // build the connection properties with some default extra ones
   lazy val connectionProperties: Map[String, String] = {
@@ -126,13 +127,17 @@ class JdbcDataLink(url: LazyConfig[String],
   }
 
   // Translate partition information to properties map usable by spark
-  private def convertToReadParamsMap(partitionColumn: String,
-                                     lowerBound: Long,
-                                     upperBound: Long,
-                                     numPartitions: Long): Map[String, String] = {
-    Map("partitionColumn" -> partitionColumn,
-        "lowerBound"      -> lowerBound.toString,
-        "upperBound"      -> upperBound.toString,
-        "numPartitions"   -> numPartitions.toString)
+  private def convertToReadParamsMap(
+      partitionColumn: String,
+      lowerBound: Long,
+      upperBound: Long,
+      numPartitions: Long
+  ): Map[String, String] = {
+    Map(
+      "partitionColumn" -> partitionColumn,
+      "lowerBound"      -> lowerBound.toString,
+      "upperBound"      -> upperBound.toString,
+      "numPartitions"   -> numPartitions.toString
+    )
   }
 }

--- a/lighthouse-core/src/main/scala/be/dataminded/lighthouse/pipeline/Sinks.scala
+++ b/lighthouse-core/src/main/scala/be/dataminded/lighthouse/pipeline/Sinks.scala
@@ -38,7 +38,8 @@ class PartitionedOrcSink(path: String, partitionsColumns: Seq[String], mode: Sav
         .mode(mode)
         .option("compression", "zlib")
         .partitionBy(partitionsColumns: _*)
-        .orc(path)) match {
+        .orc(path)
+    ) match {
       case Success(_) => SaveSuccess
       case Failure(e) =>
         logger.warn("Something went wrong writing the dataset", e)

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/FileSystemDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/FileSystemDataLinkTest.scala
@@ -36,7 +36,9 @@ class FileSystemDataLinkTest extends SparkFunSuite with Matchers with BeforeAndA
         StructField("id", ByteType) ::
           StructField("firstName", StringType, nullable = true) ::
           StructField("lastName", StringType, nullable = true) ::
-          StructField("yearOfBirth", ShortType, nullable = true) :: Nil))
+          StructField("yearOfBirth", ShortType, nullable = true) :: Nil
+      )
+    )
     val link    = new FileSystemDataLink(path = customerPath, format = Csv, options = options, schema = schema)
     val dataset = link.read()
 

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/datalake/HiveDataLinkTest.scala
@@ -33,27 +33,29 @@ class HiveDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfterEa
     import spark.implicits._
     val filePath = "./target/output/orc"
     import org.apache.spark.sql.functions._
-    val saveMode = SaveMode.Overwrite
+    val saveMode    = SaveMode.Overwrite
     val ingestDate1 = LocalDate.of(1982, DECEMBER, 21)
-    val dataset1 = Seq(Models.RawCustomer("1", "Pascal", "Knapen", "1982")).toDS()
+    val dataset1 = Seq(Models.RawCustomer("1", "Pascal", "Knapen", "1982"))
+      .toDS()
       .withColumn("ingestDate", lit(java.sql.Date.valueOf(ingestDate1)))
-    val ref = new HiveDataLink(path = filePath, database = "default", table = "customer",
-      partitionedBy = List("ingestDate"))
+    val ref =
+      new HiveDataLink(path = filePath, database = "default", table = "customer", partitionedBy = List("ingestDate"))
     ref.snapshotOf(LocalDate.of(1982, DECEMBER, 21))
     ref.write(dataset1)
     ref.readAs[Models.RawCustomer]().count should equal(1)
     val rootFile = new java.io.File(filePath)
     rootFile.listFiles.filter(_.isDirectory).toList should
-      (contain (new java.io.File(s"$filePath/ingestDate=1982-12-21")) and have length 1)
+      (contain(new java.io.File(s"$filePath/ingestDate=1982-12-21")) and have length 1)
 
     val ingestDate2 = LocalDate.of(1982, DECEMBER, 22)
-    val dataset2 = Seq(Models.RawCustomer("2", "Elisabeth", "Moss", "1982")).toDS()
+    val dataset2 = Seq(Models.RawCustomer("2", "Elisabeth", "Moss", "1982"))
+      .toDS()
       .withColumn("ingestDate", lit(java.sql.Date.valueOf(ingestDate2)))
 
     ref.write(dataset2)
     ref.readAs[Models.RawCustomer]().count should equal(2)
     rootFile.listFiles.filter(_.isDirectory).toList should
-      (contain (new java.io.File(s"$filePath/ingestDate=1982-12-22")) and have length 2)
+      (contain(new java.io.File(s"$filePath/ingestDate=1982-12-22")) and have length 2)
   }
 
   test("A hive data reference can be used to write a dataframe") {
@@ -106,7 +108,7 @@ class HiveDataLinkTest extends SparkFunSuite with Matchers with BeforeAndAfterEa
     //name = "customer", database = "default", description = null, tableType = "EXTERNAL", isTemporary = false))
   }
 
-  override def beforeEach(): Unit =  {
+  override def beforeEach(): Unit = {
     ("target" / "output").delete(swallowIOExceptions = true)
   }
 }

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/SparkFunctionTest.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/SparkFunctionTest.scala
@@ -207,9 +207,11 @@ class SparkFunctionTest extends FunSpec with Matchers with SharedSparkSession wi
         Seq(RawPerson("Bernard Chanson", 34), RawPerson("Ron Swanson", 35), RawPerson("Karl von Bauchspeck", 28)).toDS()
 
       assertDatasetEquality(spark.read.orc("./target/output/orc").as[RawPerson], expected, orderedComparison = false)
-      assertDatasetEquality(spark.read.parquet("./target/output/parquet").as[RawPerson],
-                            expected,
-                            orderedComparison = false)
+      assertDatasetEquality(
+        spark.read.parquet("./target/output/parquet").as[RawPerson],
+        expected,
+        orderedComparison = false
+      )
     }
 
     object PersonTransformations {

--- a/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/TextSinkSpec.scala
+++ b/lighthouse-core/src/test/scala/be/dataminded/lighthouse/pipeline/TextSinkSpec.scala
@@ -16,7 +16,8 @@ class TextSinkSpec extends FunSpec with SharedSparkSession with Matchers with Be
 
       ("target" / "output" / "text").glob("*.txt").map(_.contentAsString).toSeq should contain theSameElementsAs Seq(
         "datadata\n",
-        "datadatadata\n")
+        "datadatadata\n"
+      )
     }
   }
 

--- a/lighthouse-demo/src/main/scala/be/dataminded/lighthouse/demo/AirplaneDatalake.scala
+++ b/lighthouse-demo/src/main/scala/be/dataminded/lighthouse/demo/AirplaneDatalake.scala
@@ -8,32 +8,36 @@ import org.apache.spark.sql.SaveMode
 object AirplaneDatalake extends Datalake {
 
   environment("test") { refs =>
-    refs += DataUID("raw", "airplane") -> new FileSystemDataLink(resource("data/airplane"),
-                                                                 Csv,
-                                                                 SaveMode.ErrorIfExists,
-                                                                 options =
-                                                                   Map("header" -> "true", "inferSchema" -> "true"))
+    refs += DataUID("raw", "airplane") -> new FileSystemDataLink(
+      resource("data/airplane"),
+      Csv,
+      SaveMode.ErrorIfExists,
+      options = Map("header" -> "true", "inferSchema" -> "true")
+    )
 
-    refs += DataUID("raw.weather", "daily") -> new FileSystemDataLink(resource("data/weather/daily"),
-                                                                      Csv,
-                                                                      SaveMode.ErrorIfExists,
-                                                                      options = Map("header"      -> "true",
-                                                                                    "inferSchema" -> "true"))
+    refs += DataUID("raw.weather", "daily") -> new FileSystemDataLink(
+      resource("data/weather/daily"),
+      Csv,
+      SaveMode.ErrorIfExists,
+      options = Map("header" -> "true", "inferSchema" -> "true")
+    )
 
-    refs += DataUID("raw.weather", "station") -> new FileSystemDataLink(resource("data/weather/station"),
-                                                                        Csv,
-                                                                        SaveMode.ErrorIfExists,
-                                                                        options = Map("header"      -> "true",
-                                                                                      "inferSchema" -> "true",
-                                                                                      "delimiter"   -> "|"))
+    refs += DataUID("raw.weather", "station") -> new FileSystemDataLink(
+      resource("data/weather/station"),
+      Csv,
+      SaveMode.ErrorIfExists,
+      options = Map("header" -> "true", "inferSchema" -> "true", "delimiter" -> "|")
+    )
 
     refs += DataUID("clean", "airplane") -> new FileSystemDataLink(file"target/clean/airplane".pathAsString)
     refs += DataUID("clean", "weather")  -> new FileSystemDataLink(file"target/clean/weather/daily".pathAsString)
     refs += DataUID("clean", "stations") -> new FileSystemDataLink(file"target/clean/weather/stations".pathAsString)
 
-    refs += DataUID("master", "view") -> new HiveDataLink(file"target/master/airplane/view".pathAsString,
-                                                          "default",
-                                                          "airplane_view")
+    refs += DataUID("master", "view") -> new HiveDataLink(
+      file"target/master/airplane/view".pathAsString,
+      "default",
+      "airplane_view"
+    )
   }
 
   private def resource(path: String): String = File.resource(path).pathAsString

--- a/lighthouse-demo/src/main/scala/be/dataminded/lighthouse/demo/AirplanePipeline.scala
+++ b/lighthouse-demo/src/main/scala/be/dataminded/lighthouse/demo/AirplanePipeline.scala
@@ -73,7 +73,8 @@ trait AirplanePipeline {
       .join(
         dailyWeatherWithStation,
         airlines("Origin") === dailyWeatherWithStation("IAT") && airlines("YearMonthDay") === dailyWeatherWithStation(
-          "YearMonthDay"),
+          "YearMonthDay"
+        ),
         "left_outer"
       )
       .drop("IAT")
@@ -86,7 +87,8 @@ trait AirplanePipeline {
       .join(
         dailyWeatherWithStation,
         airlines("Dest") === dailyWeatherWithStation("IAT") && airlines("YearMonthDay") === dailyWeatherWithStation(
-          "YearMonthDay"),
+          "YearMonthDay"
+        ),
         "left_outer"
       )
       .drop(dailyWeatherWithStation("YearMonthDay"))

--- a/lighthouse-demo/src/test/scala/be/dataminded/lighthouse/demo/AirplanePipelineSpec.scala
+++ b/lighthouse-demo/src/test/scala/be/dataminded/lighthouse/demo/AirplanePipelineSpec.scala
@@ -35,7 +35,8 @@ class AirplanePipelineSpec
     cleanWeatherStations.schema should equal(
       StructType(
         StructField("WBAN", IntegerType) :: StructField("IAT", StringType) :: Nil
-      ))
+      )
+    )
   }
 
   test("Small functions can be tested easier") {
@@ -50,7 +51,8 @@ class AirplanePipelineSpec
     result.schema should equal(
       StructType(
         StructField("WBAN", IntegerType, nullable = false) :: StructField("IAT", StringType) :: Nil
-      ))
+      )
+    )
   }
 
   test("We can easily test for content using one of the included DatasetComparer") {

--- a/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/DatasetComparer.scala
+++ b/lighthouse-testing/src/main/scala/be/dataminded/lighthouse/testing/DatasetComparer.scala
@@ -26,8 +26,10 @@ sealed trait DatasetComparerLike {
     } else {
       val sortedActual   = defaultSortedDataset(actual)
       val sortedExpected = defaultSortedDataset(expected)
-      assert(sortedActual.collect().sameElements(sortedExpected.collect()),
-             contentMismatchMessage(sortedActual, sortedExpected))
+      assert(
+        sortedActual.collect().sameElements(sortedExpected.collect()),
+        contentMismatchMessage(sortedActual, sortedExpected)
+      )
     }
   }
 

--- a/project/Predef.scala
+++ b/project/Predef.scala
@@ -1,7 +1,7 @@
 object Predef {
   
   val scala211 = "2.11.12"
-  val scala212 = "2.12.8"
+  val scala212 = "2.12.10"
   val supportedScalaVersions = List(scala211, scala212)
   
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,9 @@
 addSbtPlugin("com.typesafe.sbt"   % "sbt-git"            % "1.0.0")
-addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.14.0")
-addSbtPlugin("com.geirsson"       % "sbt-scalafmt"       % "1.4.0")
-addSbtPlugin("io.get-coursier"    % "sbt-coursier"       % "1.0.0")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage"      % "1.5.1")
-addSbtPlugin("com.typesafe.sbt"   % "sbt-site"           % "1.3.2")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"       % "2.3.0")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"      % "1.6.1")
+addSbtPlugin("com.typesafe.sbt"   % "sbt-site"           % "1.4.0")
 
 // Publish to Maven Central
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
-addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "1.1.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "2.0.1")


### PR DESCRIPTION
Just a fresh wind blow to chase out stale air.
FYI: I'm up to carry on with the libraries in the upcoming requests.

What's been done in this PR:
- use SBT 1.3.6 with Coursier out-of-the-box;
- drop the redundant sbt-coursier plugin;
- update all the other plugins to their latest versions;
- update scalafmt version.